### PR TITLE
feat: Add Docker support and update README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# Use a lightweight Python base image
+FROM python:3.11-slim
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy the requirements file and install dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the rest of the application files
+COPY . .
+
+# Expose the port for the Streamlit app
+EXPOSE 8501
+
+# Set the default command to run the Streamlit app
+CMD ["streamlit", "run", "app.py"]

--- a/README.md
+++ b/README.md
@@ -4,5 +4,34 @@ A persistent RAG (Retrieval-Augmented Generation) system that answers questions 
 
 Some examples of chat with .txt,duckdb and sqlite as context.
 
+## Running with Docker
+
+### Build the Docker Image
+```bash
+docker build -t rag-app .
+```
+
+### Run the Applications
+
+You can run any of the three Python scripts using the Docker image.
+
+#### 1. Run the Streamlit Web App (`app.py`)
+This is the default command for the Docker container. It will start a web server on port 8501.
+```bash
+docker run -p 8501:8501 rag-app
+```
+Open your browser and navigate to `http://localhost:8501` to use the application.
+
+#### 2. Run the DuckDB RAG Script (`ragtodb.py`)
+This script runs in the command line.
+```bash
+docker run -it rag-app python ragtodb.py
+```
+
+#### 3. Run the SQLite RAG Script (`ragtosqlite.py`)
+This script also runs in the command line.
+```bash
+docker run -it rag-app python ragtosqlite.py
+```
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ httpx
 requests
 numpy
 pandas
+streamlit


### PR DESCRIPTION
This commit introduces a Dockerfile to allow the application to be run in a containerized environment.

- A lightweight Dockerfile based on `python:3.11-slim` is added.
- The `streamlit` dependency, required for `app.py`, is added to `requirements.txt`.
- The `README.md` is updated with instructions on how to build the Docker image and run each of the three Python scripts (`app.py`, `ragtodb.py`, and `ragtosqlite.py`).